### PR TITLE
Bump action versions in nightly GitHub Actions workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -63,7 +63,7 @@ jobs:
         run: echo "${{ env.ARTICHOKE_NIGHTLY_VERSION }}" > artifacts/release-version
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: artifacts
           path: artifacts
@@ -130,18 +130,6 @@ jobs:
         with:
           ruby-version: ".ruby-version"
 
-      - name: Install Clang
-        run: sudo apt install clang
-        if: matrix.os == 'ubuntu-latest'
-
-      - name: Install Clang
-        run: choco install llvm --no-progress
-        if: matrix.os == 'windows-latest'
-
-      - name: Install Bison
-        run: sudo apt install bison
-        if: matrix.os == 'ubuntu-latest'
-
       # avoid choco because it takes forever to initialize on first use
       # instead, install directly from GitHub releases
       - name: Install Bison
@@ -156,7 +144,7 @@ jobs:
         if: matrix.build == 'linux-musl'
 
       - name: Get release download URL
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v2
         with:
           name: artifacts
           path: artifacts
@@ -220,7 +208,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get release download URL
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v2
         with:
           name: artifacts
           path: artifacts


### PR DESCRIPTION
- Remove unnecessary bison and clang install steps to sync with upstream
Artichoke Actions configuration.