### PR TITLE
Use updated GitHub Actions environment file syntax

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -173,7 +173,7 @@ jobs:
         if: runner.os == 'Linux' || runner.os == 'macOS'
         # strip binary artifacts with a linker flag
         # https://github.com/rust-lang/cargo/issues/3483#issuecomment-431209957
-        run: echo "::set-env name=RUSTFLAGS::-C link-arg=-s"
+        run: echo "RUSTFLAGS=-C link-arg=-s" >> $GITHUB_ENV
 
       - name: Build release artifacts
         working-directory: artichoke


### PR DESCRIPTION
The nightly workflow dynamically sets the `RUSTFLAGS` environment
variable depending on host platform to enable symbol stripping in the
linker.

CVE-2020-15228 is a vulnerability in the GitHub Actions hosted runner
that will interpret arbitrary `set-env` and `add-path` sequences in
stdout logs, including untrusted output.

GitHub has stated that they are immediately deprecating these commands
and intend to remove them in the near future:

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

This PR replaces the `set-env` magic stdout sequence with an append to
the special `$GITHUB_ENV` file.