### PR TITLE
Use updated GitHub Actions path file syntax

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -163,7 +163,7 @@ jobs:
         run: |
           (New-Object System.Net.WebClient).DownloadFile("https://github.com/lexxmark/winflexbison/releases/download/v2.5.22/win_flex_bison-2.5.22.zip","win_flex_bison.zip");
           Expand-Archive .\win_flex_bison.zip .\win_flex_bison;
-          echo "::add-path::${{ github.workspace }}/win_flex_bison"
+          echo "${{ github.workspace }}/win_flex_bison" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
 
       - name: Install musl
         if: matrix.build == 'linux-musl'


### PR DESCRIPTION
The nightly workflow dynamically sets the `PATH` environment
variable on Windows to access a custom `win_flex_bison` artifact when
building mruby.

CVE-2020-15228 is a vulnerability in the GitHub Actions hosted runner
that will interpret arbitrary `set-env` and `add-path` sequences in
stdout logs, including untrusted output.

GitHub has stated that they are immediately deprecating these commands
and intend to remove them in the near future:

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

This PR replaces the `add-path` magic stdout sequence with an append to
the special `$GITHUB_PATH` file.