### PR TITLE
Remove bison installation from GitHub Actions workflows

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -156,32 +156,6 @@ jobs:
         with:
           ruby-version: ".ruby-version"
 
-      # Avoid using the `choco` package manager to install deps on Windows
-      # runners because it takes a non-trivial amount of time to initialize on
-      # first use. Instead, install `bison` directly from GitHub releases using
-      # native PowerShell cmdlets.
-      #
-      # `win_flex_bison` is the same `bison` mruby installs for Windows builds
-      # in its CI configuration.
-      #
-      # https://github.com/artichoke/artichoke/blob/5a98788e/artichoke-backend/vendor/mruby/appveyor.yml#L35
-      #
-      # See upstream PRs in Artichoke that developed this step:
-      #
-      # - https://github.com/artichoke/artichoke/pull/686
-      # - https://github.com/artichoke/artichoke/pull/872
-      # - https://github.com/artichoke/artichoke/pull/913
-      - name: Install Bison
-        run: |
-          $winFlexBison = Join-Path -Path $env:temp  -ChildPath $(New-Guid)
-          $releaseArchive = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } -PassThru
-          Invoke-WebRequest $env:ARTIFACT_URL -OutFile $releaseArchive
-          $releaseArchive | Expand-Archive -DestinationPath $winFlexBison
-          $winFlexBison | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
-        env:
-          ARTIFACT_URL: https://github.com/lexxmark/winflexbison/releases/download/v2.5.22/win_flex_bison-2.5.22.zip
-        if: runner.os == 'Windows'
-
       - name: Install musl
         if: matrix.build == 'linux-musl'
         run: sudo apt install musl-tools


### PR DESCRIPTION
Since artichoke/artichoke#936 and artichoke/artichoke#990, the vendored
copy of mruby has included a pre-built y.tab.c parser generated from
`parse.y`. `artichoke-backend` uses this generated parser directly. This
removes the last dependency on the mruby rake infrastructure for
generating sources.

See also artichoke/artichoke#997 which makes this same change upstream.