### PR TITLE
Cross-compile Apple Silicon nightlies on macOS runner

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -98,7 +98,7 @@ jobs:
             os: macos-latest
             target: x86_64-apple-darwin
           - build: macos-apple-silicon
-            os: macos-latest
+            os: macos-11.0
             target: aarch64-apple-darwin
           - build: windows
             os: windows-latest

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -85,6 +85,7 @@ jobs:
           - linux
           - linux-musl
           - macos
+          - macos-apple-silicon
           - windows
         include:
           - build: linux
@@ -96,6 +97,9 @@ jobs:
           - build: macos
             os: macos-latest
             target: x86_64-apple-darwin
+          - build: macos-apple-silicon
+            os: macos-latest
+            target: aarch64-apple-darwin
           - build: windows
             os: windows-latest
             target: x86_64-pc-windows-msvc


### PR DESCRIPTION
With [Rust 1.49.0 landed][0] and Artichoke using a 1.49.0 toolchain
(artichoke/artichoke#991), nightly builds can cross-compile Apple
Silicon builds of Artichoke on `macos-11.0` runners.

Fixes #14.

[0]: https://blog.rust-lang.org/2020/12/31/Rust-1.49.0.html#64-bit-arm-macos-and-windows-reach-tier-2