### PR TITLE
Add aarch64-apple-darwin target to README as supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Currently supported nightly targets are:
 - `x86_64-unknown-linux-musl`
 - `x86_64-apple-darwin`
 - `x86_64-pc-windows-msvc`
+- `aarch64-apple-darwin` (Apple Silicon)
 
 [artichoke ruby]: https://github.com/artichoke/artichoke
 [docker-nightly]: https://github.com/artichoke/docker-artichoke-nightly


### PR DESCRIPTION
With #17, Apple Silicon builds are being generated on nightly runs.