### PR TITLE
Add gpg code signing to nightly workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -160,6 +160,13 @@ jobs:
         with:
           ruby-version: ".ruby-version"
 
+      - name: Import GPG key
+        id: import_gpg
+        uses: artichoke/ghaction-import-gpg@v2.1.0
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.GPG_SIGNING_KEY_PASSPHRASE }}
+
       - name: Install musl
         if: matrix.build == 'linux-musl'
         run: sudo apt install musl-tools
@@ -185,12 +192,16 @@ jobs:
             cp "artichoke/target/${{ matrix.target }}/release/artichoke.exe" "$staging/"
             cp "artichoke/target/${{ matrix.target }}/release/airb.exe" "$staging/"
             "/c/Program Files/7-Zip/7z.exe" a "$staging.zip" "$staging"
+            echo "${{ secrets.GPG_SIGNING_KEY_PASSPHRASE }}" | gpg --passphrase-fd 0 --pinentry-mode loopback --batch --yes --detach-sign --armor --local-user AF57A37CAC061452 --output  "$staging.zip.asc" "$staging.zip"
+            gpg --batch --verify "$staging.zip.asc" "$staging.zip"
             echo "::set-output name=asset::$staging.zip"
             echo "::set-output name=content_type::application/zip"
           else
             cp "artichoke/target/${{ matrix.target }}/release/artichoke" "$staging/"
             cp "artichoke/target/${{ matrix.target }}/release/airb" "$staging/"
             tar czf "$staging.tar.gz" "$staging"
+            echo "${{ secrets.GPG_SIGNING_KEY_PASSPHRASE }}" | gpg --passphrase-fd 0 --pinentry-mode loopback --batch --yes --detach-sign --armor --local-user AF57A37CAC061452 --output  "$staging.tar.gz.asc" "$staging.tar.gz"
+            gpg --batch --verify "$staging.tar.gz.asc" "$staging.tar.gz"
             echo "::set-output name=asset::$staging.tar.gz"
             echo "::set-output name=content_type::application/gzip"
           fi
@@ -204,6 +215,16 @@ jobs:
           asset_path: ${{ steps.build.outputs.asset }}
           asset_name: ${{ steps.build.outputs.asset }}
           asset_content_type: ${{ steps.build.outputs.content_type }}
+
+      - name: Upload release signature
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.release_info.outputs.upload_url }}
+          asset_path: ${{ steps.build.outputs.asset }}.asc
+          asset_name: ${{ steps.build.outputs.asset }}.asc
+          asset_content_type: "text/plain"
 
   finalize-release:
     name: Publish Release

--- a/README.md
+++ b/README.md
@@ -37,7 +37,20 @@ Currently supported nightly targets are:
 - `x86_64-pc-windows-msvc`
 - `aarch64-apple-darwin` (Apple Silicon)
 
+## Code Signing
+
+Release artifacts are signed with the the following GPG key:
+
+**User ID**: Code signing for Artichoke Ruby \<codesign@artichokeruby.org\>  
+**Signing Key ID**: AF57A37CAC061452  
+**Signing Key Fingerprint**: 1C4A856ACF86EC1EE841180FAF57A37CAC061452  
+**Public Key**: <https://github.com/artichoke-ci.gpg>, [artichoke/nightly#20],
+[artichoke/nightly@84e687e866edb52a43a4f462accf3020fe8797f1].
+
 [artichoke ruby]: https://github.com/artichoke/artichoke
 [docker-nightly]: https://github.com/artichoke/docker-artichoke-nightly
 [nightly-releases]: https://github.com/artichoke/nightly/releases
 [`ruby-build`]: https://github.com/rbenv/ruby-build
+[artichoke/nightly#20]: https://github.com/artichoke/nightly/pull/20
+[artichoke/nightly@84e687e866edb52a43a4f462accf3020fe8797f1]:
+  https://github.com/artichoke/nightly/commit/84e687e866edb52a43a4f462accf3020fe8797f1


### PR DESCRIPTION
Add GPG code signing to nightly workflow

Sign release tarballs and zipballs with the following GPG key:

**User ID**: Code signing for Artichoke Ruby \<codesign@artichokeruby.org\>
**Signing Key ID**: AF57A37CAC061452
**Signing Key Fingerprint**: 1C4A856ACF86EC1EE841180FAF57A37CAC061452
**Public Key**: <https://github.com/artichoke-ci.gpg>, artichoke/nightly#20

```
-----BEGIN PGP PUBLIC KEY BLOCK-----

mDMEX/IrgxYJKwYBBAHaRw8BAQdA6rMZoRTZv6ENkud+nxfk9HfNV1FvsOCYP+VR
LWmUF1O0PENvZGUgc2lnbmluZyBmb3IgQXJ0aWNob2tlIFJ1YnkgPGNvZGVzaWdu
QGFydGljaG9rZXJ1Ynkub3JnPoiQBBMWCAA4FiEEyYOPEEAh9Z7m9ry+sZnQNH/a
FKQFAl/yK4MCGwMFCwkIBwIGFQoJCAsCBBYCAwECHgECF4AACgkQsZnQNH/aFKSg
iQEAwRFgu0fB+RqsnlSnuhq/k0wkYzqKRk/Cn2tVAp/7Ig0BAN4RpIHLIBuzYKYR
nY7MScuKvbzCnADJNxZShoUZteoPuDgEX/IrgxIKKwYBBAGXVQEFAQEHQJVJmYxU
3Sz8OzDK014vVssn+3C1dC9q7zVweb7IkcY8AwEIB4h4BBgWCAAgFiEEyYOPEEAh
9Z7m9ry+sZnQNH/aFKQFAl/yK4MCGwwACgkQsZnQNH/aFKRGZgD/Ug5tGItj3GYT
ECTlwbAsyxrhdW045Ddl2uw5epnY6GAA/0equokFotiYTI7PHPmerP1fQQIl2cHC
C3zT47MsvosBuDMEX/IsyhYJKwYBBAHaRw8BAQdA/+xQVpaZO5VJqBd8MpQDMvXU
AQJ10WqCSF9tc/uLaaKI7wQYFggAIBYhBMmDjxBAIfWe5va8vrGZ0DR/2hSkBQJf
8izKAhsCAIEJELGZ0DR/2hSkdiAEGRYIAB0WIQQcSoVqz4bsHuhBGA+vV6N8rAYU
UgUCX/IsygAKCRCvV6N8rAYUUlq5AQCKwtdEJboo10L8xgbBfjfXqTmXwVZEuZCn
N4wIwNATbwEA2L2Q4MjSORTIBAWb25OcP+E2sry0tbcGAXosLVRaXgqlkQD/YQXi
2DDwJ3n0a+3GpOB8m4H1dBwKE3pRADAqCT2CR3UBAKUNsnlTssA8VxSJj50xyH1Z
OA55wz5Bm3xklwDJ4mYM
=RXFA
-----END PGP PUBLIC KEY BLOCK-----
```

This GPG key is attached to the @artichoke-ci GitHub user. @artichoke-ci
is a member of the @artichoke organization:

https://github.com/orgs/artichoke/people

This GPG key is attached to @artichoke-ci on GitHub and can be retrieved
from:

https://github.com/artichoke-ci.gpg