### PR TITLE
Add Nightly Builder workflow badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Artichoke Nightly Builds
 
 [![GitHub Actions](https://github.com/artichoke/nightly/workflows/CI/badge.svg)](https://github.com/artichoke/nightly/actions)
+[![Nightly Build](https://github.com/artichoke/nightly/workflows/Nightly%20Builder/badge.svg)](https://github.com/artichoke/nightly/actions)
 [![Discord](https://img.shields.io/discord/607683947496734760)](https://discord.gg/QCe2tp2)
 [![Twitter](https://img.shields.io/twitter/follow/artichokeruby?label=Follow&style=social)](https://twitter.com/artichokeruby)
 


### PR DESCRIPTION
This workflow runs repeatedly and most accurately reflects the current
health of the build.

See also https://github.com/artichoke/docker-artichoke-nightly/pull/31.