### PR TITLE
Update `aarch64-apple-darwin` matrix config for `macos-11` runner GA

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -98,7 +98,7 @@ jobs:
             os: macos-latest
             target: x86_64-apple-darwin
           - build: macos-apple-silicon
-            os: macos-11.0
+            os: macos-11
             target: aarch64-apple-darwin
           - build: windows
             os: windows-latest


### PR DESCRIPTION
https://github.blog/changelog/2021-08-16-github-actions-macos-11-big-sur-is-generally-available-on-github-hosted-runners/

The label was changed from `macos-11.0` to `macos-11` as part of the transition to GA.

https://github.com/actions/virtual-environments/blob/cabf79fd204210d9aac50745c4ae245dc4e336fe/docs/macos-11-onboarding.md#usage