### PR TITLE
Update nightly builder to use `artichoke/ghaction-import-gpg@v4.1.0`

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -152,10 +152,11 @@ jobs:
 
       - name: Import GPG key
         id: import_gpg
-        uses: artichoke/ghaction-import-gpg@v2.1.0
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.GPG_SIGNING_KEY_PASSPHRASE }}
+        uses: artichoke/ghaction-import-gpg@v4.1.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_SIGNING_KEY_PASSPHRASE }}
+          fingerprint: 1C4A856ACF86EC1EE841180FAF57A37CAC061452
 
       - name: Install musl
         if: matrix.build == 'linux-musl'
@@ -182,19 +183,20 @@ jobs:
             cp "artichoke/target/${{ matrix.target }}/release/artichoke.exe" "$staging/"
             cp "artichoke/target/${{ matrix.target }}/release/airb.exe" "$staging/"
             7z a "$staging.zip" "$staging"
-            echo "${{ secrets.GPG_SIGNING_KEY_PASSPHRASE }}" | gpg --passphrase-fd 0 --pinentry-mode loopback --batch --yes --detach-sign --armor --local-user AF57A37CAC061452 --output  "$staging.zip.asc" "$staging.zip"
-            gpg --batch --verify "$staging.zip.asc" "$staging.zip"
             echo "::set-output name=asset::$staging.zip"
             echo "::set-output name=content_type::application/zip"
           else
             cp "artichoke/target/${{ matrix.target }}/release/artichoke" "$staging/"
             cp "artichoke/target/${{ matrix.target }}/release/airb" "$staging/"
             tar czf "$staging.tar.gz" "$staging"
-            echo "${{ secrets.GPG_SIGNING_KEY_PASSPHRASE }}" | gpg --passphrase-fd 0 --pinentry-mode loopback --batch --yes --detach-sign --armor --local-user AF57A37CAC061452 --output  "$staging.tar.gz.asc" "$staging.tar.gz"
-            gpg --batch --verify "$staging.tar.gz.asc" "$staging.tar.gz"
             echo "::set-output name=asset::$staging.tar.gz"
             echo "::set-output name=content_type::application/gzip"
           fi
+
+      - name: GPG sign archive
+        run: |
+          gpg --batch --yes --detach-sign --armor --local-user "${{ steps.import_gpg.outputs.fingerprint }}" --output "${{ steps.build.outputs.asset }}.asc" "${{ steps.build.outputs.asset }}"
+          gpg --batch --verify "${{ steps.build.outputs.asset }}.asc" "${{ steps.build.outputs.asset }}"
 
       - name: Upload release archive
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
This change fixes some CVEs in the npm packages this action depends on.

Changes to the use of the action include:

- Specifiy the signing subkey fingerprint.
- Use the action step outputs to pass the key fingerprint to gpg.
- Rely on the signing key passphrase being loaded into the GPG agent by
  the action instead of echoing it to gpg over stdin.

Further simplifications of gpg usage come from moving gpg signing out of
the build step by relying on build step asset outputs to perform the
signing in one place.

Further work on #32. Once this is merged and the nightly builder runs
successfully, #32 can be closed out and completed.