### PR TITLE
Upgrade `ghaction-import-gpg` to v5.1.0

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -150,13 +150,26 @@ jobs:
           profile: minimal
           target: ${{ matrix.target }}
 
+      # ```
+      # $ gpg --fingerprint --with-subkey-fingerprints codesign@artichokeruby.org
+      # pub   ed25519 2021-01-03 [SC]
+      #       C983 8F10 4021 F59E E6F6  BCBE B199 D034 7FDA 14A4
+      # uid           [ultimate] Code signing for Artichoke Ruby <codesign@artichokeruby.org>
+      # sub   cv25519 2021-01-03 [E]
+      #       7719 1B6D 83B2 F4E8 5197  125B A9A3 F70E 710A 15AA
+      # sub   ed25519 2021-01-03 [S]
+      #       1C4A 856A CF86 EC1E E841  180F AF57 A37C AC06 1452
+      # ```
       - name: Import GPG key
         id: import_gpg
-        uses: artichoke/ghaction-import-gpg@v4.1.0
+        uses: artichoke/ghaction-import-gpg@v5.1.0
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_SIGNING_KEY_PASSPHRASE }}
           fingerprint: 1C4A856ACF86EC1EE841180FAF57A37CAC061452
+
+      - name: List keys
+        run: gpg -K
 
       - name: Install musl
         if: matrix.build == 'linux-musl'


### PR DESCRIPTION
`artichoke/ghaction-import-gpg` is synced from upstream which includes several new releases, including a breaking change to v5 which upgrades the nodejs runtime version.

The tag in `artichoke/ghaction-import-gpg` is:

- https://github.com/artichoke/ghaction-import-gpg/tree/v5.1.0

Diff of the upgrade from v4.1.0 to v5.1.0 is:

- https://github.com/artichoke/ghaction-import-gpg/compare/v4.1.0..v5.1.0

The diff is mostly tests and linting, with some changes to how key fingerprints and subkeys are handled, most notably:

- https://github.com/crazy-max/ghaction-import-gpg/pull/123
- https://github.com/crazy-max/ghaction-import-gpg/pull/125
- https://github.com/crazy-max/ghaction-import-gpg/pull/129

`artichoke/nightly` uses a signing subkey, so these fixes are good to take.