### PR TITLE
Bundle third party license listing with release artifacts

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -141,6 +141,13 @@ jobs:
           echo "::set-output name=version::${release_version}"
           echo "::set-output name=commit::${release_commit}"
 
+      - name: Generate THIRDPARTY license listing
+        id: generate_third_party
+        uses: artichoke/generate_third_party@trunk
+        with:
+          artichoke_ref: ${{ steps.release_info.outputs.commit }}
+          target_triple: ${{ matrix.target }}
+
       - name: Clone Artichoke
         uses: actions/checkout@v3
         with:
@@ -199,6 +206,7 @@ jobs:
           staging="artichoke-nightly-${{ matrix.target }}"
           mkdir -p "$staging"/
           cp artichoke/{README.md,LICENSE} "$staging/"
+          echo "$THIRD_PARTY_LICENSES" > "$staging/THIRDPARTY.txt"
           if [ "${{ runner.os }}" = "Windows" ]; then
             cp "artichoke/target/${{ matrix.target }}/release/artichoke.exe" "$staging/"
             cp "artichoke/target/${{ matrix.target }}/release/airb.exe" "$staging/"
@@ -212,6 +220,9 @@ jobs:
             echo "::set-output name=asset::$staging.tar.gz"
             echo "::set-output name=content_type::application/gzip"
           fi
+        env:
+          THIRD_PARTY_LICENSES: |
+            ${{ steps.generate_third_party.outputs.third_party_licenses }}
 
       - name: GPG sign archive
         run: |


### PR DESCRIPTION
Release tarballs and zipballs will contain a new `THIRDPARTY.txt` file
which contains a plaintext listing of all third party dependencies in
Artichoke and their licenses.

Fixes #36.