### PR TITLE
Move GPG codesigning workflow to a Python script

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -119,6 +119,9 @@ jobs:
       RUST_BACKTRACE: 1
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Get release download URL
         uses: actions/download-artifact@v3
         with:
@@ -170,6 +173,11 @@ jobs:
         with:
           profile: minimal
           target: ${{ matrix.target }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
 
       # ```
       # $ gpg --fingerprint --with-subkey-fingerprints codesign@artichokeruby.org
@@ -223,9 +231,8 @@ jobs:
           fi
 
       - name: GPG sign archive
-        run: |
-          gpg --batch --yes --detach-sign --armor --local-user "${{ steps.import_gpg.outputs.fingerprint }}" --output "${{ steps.build.outputs.asset }}.asc" "${{ steps.build.outputs.asset }}"
-          gpg --batch --verify "${{ steps.build.outputs.asset }}.asc" "${{ steps.build.outputs.asset }}"
+        id: gpg_signing
+        run: python3 gpg_sign.py "artichoke-nightly-${{ matrix.target }}" --binary "${{ steps.build.outputs.asset }}"
 
       - name: Upload release archive
         uses: ncipollo/release-action@v1
@@ -250,7 +257,7 @@ jobs:
           omitBodyDuringUpdate: true
           omitNameDuringUpdate: true
           omitPrereleaseDuringUpdate: true
-          artifacts: ${{ steps.build.outputs.asset }}.asc
+          artifacts: ${{ steps.gpg_signing.outputs.signature }}
           artifactContentType: "text/plain"
 
   finalize-release:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -232,7 +232,7 @@ jobs:
 
       - name: GPG sign archive
         id: gpg_signing
-        run: python3 gpg_sign.py "artichoke-nightly-${{ matrix.target }}" --binary "${{ steps.build.outputs.asset }}"
+        run: python3 gpg_sign.py "artichoke-nightly-${{ matrix.target }}" --artifact "${{ steps.build.outputs.asset }}"
 
       - name: Upload release archive
         uses: ncipollo/release-action@v1

--- a/gpg_sign.py
+++ b/gpg_sign.py
@@ -154,7 +154,10 @@ def main(args):
             return 1
 
     if len(binaries) > 1:
-        print("Error: Too many --binary arguments. GPG codesigning script can only sign one binary at a time.", file=sys.stderr)
+        print(
+            "Error: Too many --binary arguments. GPG codesigning script can only sign one binary at a time.",
+            file=sys.stderr,
+        )
         return 1
 
     binary = binaries[0]

--- a/gpg_sign.py
+++ b/gpg_sign.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+
+import base64
+import binascii
+import json
+import os
+import secrets
+import shutil
+import subprocess
+import sys
+import tempfile
+import traceback
+from contextlib import contextmanager
+from pathlib import Path
+
+
+def set_output(*, name, value):
+    """
+    Set an output for a GitHub Actions job.
+
+    https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs
+    """
+
+    print(f"::set-output name={name}::{value}")
+
+
+@contextmanager
+def log_group(group):
+    """
+    Create an expandable log group in GitHub Actions job logs.
+
+    https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines
+    """
+
+    print(f"::group::{group}")
+    try:
+        yield
+    finally:
+        print("::endgroup::")
+
+
+def emit_metadata():
+    if os.getenv("CI") != "true":
+        return
+    with log_group("Workflow metadata"):
+        if repository := os.getenv("GITHUB_REPOSITORY"):
+            print(f"GitHub Repository: {repository}")
+        if actor := os.getenv("GITHUB_ACTOR"):
+            print(f"GitHub Actor: {actor}")
+        if workflow := os.getenv("GITHUB_WORKFLOW"):
+            print(f"GitHub Workflow: {workflow}")
+        if job := os.getenv("GITHUB_JOB"):
+            print(f"GitHub Job: {job}")
+        if run_id := os.getenv("GITHUB_RUN_ID"):
+            print(f"GitHub Run ID: {run_id}")
+        if ref := os.getenv("GITHUB_REF"):
+            print(f"GitHub Ref: {ref}")
+        if ref_name := os.getenv("GITHUB_REF_NAME"):
+            print(f"GitHub Ref Name: {ref_name}")
+        if sha := os.getenv("GITHUB_SHA"):
+            print(f"GitHub SHA: {sha}")
+
+
+def codesigning_identity():
+    """
+    Codesigning identity and GPG key fingerprint.
+    """
+
+    return "1C4A856ACF86EC1EE841180FAF57A37CAC061452"
+
+
+def gpg_sign_binary(*, binary_path, release_name):
+    """
+    Create a GPG signature for the given binary.
+    """
+
+    stage = Path("dist").joinpath(release_name)
+    with log_group(f"Create GPG signature [{binary_path.name}]"):
+        try:
+            shutil.rmtree(stage)
+        except FileNotFoundError:
+            pass
+        os.makedirs(stage, exist_ok=True)
+
+        asc = stage.joinpath(f"{binary_path.name}.asc")
+        subprocess.run(
+            [
+                "gpg",
+                "--batch",
+                "--yes",
+                "--detach-sign",
+                "-vv",
+                "--armor",
+                "--local-user",
+                codesigning_identity(),
+                "--output",
+                str(asc),
+                str(binary_path),
+            ],
+            check=True,
+        )
+        return asc
+
+
+def validate(*, binary_name, asc):
+    """
+    Verify GPG signature for the given binary.
+    """
+
+    with log_group("Verify GPG signature"):
+        subprocess.run(
+            [
+                "gpg",
+                "--batch",
+                "--verify",
+                "-vv",
+                str(asc),
+                str(binary_name),
+            ],
+            check=True,
+        )
+
+
+def main(args):
+    if not args:
+        print("Error: pass name of release as first argument", file=sys.stderr)
+        return 1
+
+    release_name, *args = args
+    binaries = []
+    append_next = None
+    for arg in args:
+        if append_next is None:
+            if arg == "--binary":
+                append_next = binaries
+                continue
+            print(f"Unexpected argument: {arg}", file=sys.stderr)
+            return 1
+        append_next.append(Path(arg))
+        append_next = None
+
+    if append_next is not None:
+        if append_next is binaries:
+            print("Error: unterminated --binary flag", file=sys.stderr)
+        return 1
+
+    if not binaries:
+        print("Error: no binaries passed to be codesigned", file=sys.stderr)
+        return 1
+
+    for binary in binaries:
+        if not binary.is_file():
+            print("Error: {binary} does not exist", file=sys.stderr)
+            return 1
+
+    if len(binaries) > 1:
+        print("Error: Too many --binary arguments. GPG codesigning script can only sign one binary at a time.", file=sys.stderr)
+        return 1
+
+    binary = binaries[0]
+
+    try:
+        emit_metadata()
+
+        signature = gpg_sign_binary(binary_path=binary, release_name=release_name)
+        validate(binary_name=binary, asc=signature)
+
+        set_output(name="signature", value=signature)
+
+        return 0
+    except subprocess.CalledProcessError as e:
+        print(
+            f"""Error: failed to invoke command.
+            \tCommand: {e.cmd}
+            \tReturn Code: {e.returncode}""",
+            file=sys.stderr,
+        )
+        return e.returncode
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        print(traceback.format_exc())
+        return 1
+
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    sys.exit(main(args))

--- a/gpg_sign.py
+++ b/gpg_sign.py
@@ -1,14 +1,9 @@
 #!/usr/bin/env python3
 
-import base64
-import binascii
-import json
 import os
-import secrets
 import shutil
 import subprocess
 import sys
-import tempfile
 import traceback
 from contextlib import contextmanager
 from pathlib import Path

--- a/gpg_sign.py
+++ b/gpg_sign.py
@@ -150,7 +150,10 @@ def main(args):
 
     if len(binaries) > 1:
         print(
-            "Error: Too many --binary arguments. GPG codesigning script can only sign one binary at a time.",
+            (
+                "Error: Too many --binary arguments. "
+                "GPG codesigning script can only sign one binary at a time."
+            ),
             file=sys.stderr,
         )
         return 1

--- a/macos_sign_and_notarize.py
+++ b/macos_sign_and_notarize.py
@@ -462,7 +462,7 @@ def notarize_bundle(*, bundle):
             ],
             check=True,
             capture_output=True,
-            encoding="utf8",
+            text=True,
         )
         if proc.stderr:
             print(proc.stderr, file=sys.stderr)


### PR DESCRIPTION
Following up on the success in #84, extract complicated GPG codesigning steps to a Python script.

This will make it easier to reuse this workflow when we start GPG signing the Apple DMGs.

The structure and CLI argument format of the script is borrowed from `macos_sign_and_notarize.py`. Unlike `macos_sign_and_notarize.py`, `gpg_sign.py` operates on one artifact.