### PR TITLE
Improve logging in Apple codesigning script

### DIFF
--- a/gpg_sign.py
+++ b/gpg_sign.py
@@ -28,7 +28,8 @@ def run_command_with_merged_output(command):
         text=True,
     )
     for line in proc.stdout.splitlines():
-        print(line)
+        if line:
+            print(line)
 
 
 def set_output(*, name, value):


### PR DESCRIPTION
Followup to #88. Some logging and code duplication improvements.

Add a helper method for running a command, merging stdout and stderr, and printing the output.