### PR TITLE
Filter empty keychain search paths

### DIFF
--- a/macos_sign_and_notarize.py
+++ b/macos_sign_and_notarize.py
@@ -291,8 +291,11 @@ def create_keychain(*, keychain_password):
             stderr=subprocess.STDOUT,
             text=True,
         )
+
         search_path = [line.strip().strip('"') for line in proc.stdout.splitlines()]
+        search_path = [keychain for keychain in search_path if keychain]
         search_path.append(str(keychain_path()))
+
         run_command_with_merged_output(
             ["security", "list-keychains", "-d", "user", "-s"] + search_path
         )


### PR DESCRIPTION
This can appear if there are not keychains already in the search path or
if the `security list-keychains` command outputs any blank lines.