### PR TITLE
Add `aarch64-linux-gnu` nightlies

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -210,7 +210,10 @@ jobs:
 
       - name: Install gcc aarch64 cross compiler
         if: matrix.build == 'linux-arm64'
-        run: sudo apt install gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
+        run: |
+          sudo apt install gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
+          # https://github.com/rust-lang/rust-bindgen/issues/1229
+          echo 'BINDGEN_EXTRA_CLANG_ARGS=--sysroot=/usr/aarch64-linux-gnu' >> $GITHUB_ENV
 
       - name: Build release artifacts
         working-directory: artichoke

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -214,6 +214,8 @@ jobs:
           sudo apt install gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
           # https://github.com/rust-lang/rust-bindgen/issues/1229
           echo 'BINDGEN_EXTRA_CLANG_ARGS=--sysroot=/usr/aarch64-linux-gnu' >> $GITHUB_ENV
+          # https://github.com/rust-lang/rust/issues/28924
+          echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc' >> $GITHUB_ENV
 
       - name: Build release artifacts
         working-directory: artichoke

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -97,7 +97,6 @@ jobs:
           - linux-x64
           - linux-x64-musl
           - linux-arm64
-          - linux-arm64-musl
           - macos-x64
           - macos-arm64
           - windows-x64
@@ -111,9 +110,6 @@ jobs:
           - build: linux-arm64
             os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-          - build: linux-arm64-musl
-            os: ubuntu-latest
-            target: aarch64-unknown-linux-musl
           - build: macos-x64
             os: macos-latest
             target: x86_64-apple-darwin
@@ -215,13 +211,6 @@ jobs:
       - name: Install gcc aarch64 cross compiler
         if: matrix.build == 'linux-arm64'
         run: sudo apt install gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
-
-      - name: Install musl aarch64 cross compiler
-        if: matrix.build == 'linux-arm64-musl'
-        run: |
-          curl --silent --show-error --retry 5 --fail -O https://musl.cc/aarch64-linux-musl-cross.tgz
-          tar xzf aarch64-linux-musl-cross.tgz
-          echo "${{github.workspace}}/aarch64-linux-musl-cross/bin" >> $GITHUB_PATH
 
       - name: Build release artifacts
         working-directory: artichoke

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -94,25 +94,33 @@ jobs:
       fail-fast: false
       matrix:
         build:
-          - linux
-          - linux-musl
-          - macos
-          - macos-apple-silicon
-          - windows
+          - linux-x64
+          - linux-x64-musl
+          - linux-arm64
+          - linux-arm64-musl
+          - macos-x64
+          - macos-arm64
+          - windows-x64
         include:
-          - build: linux
+          - build: linux-x64
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          - build: linux-musl
+          - build: linux-x64-musl
             os: ubuntu-latest
             target: x86_64-unknown-linux-musl
-          - build: macos
+          - build: linux-arm64
+            os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+          - build: linux-arm64-musl
+            os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+          - build: macos-x64
             os: macos-latest
             target: x86_64-apple-darwin
-          - build: macos-apple-silicon
+          - build: macos-arm64
             os: macos-11
             target: aarch64-apple-darwin
-          - build: windows
+          - build: windows-x64
             os: windows-latest
             target: x86_64-pc-windows-msvc
     env:
@@ -200,9 +208,20 @@ jobs:
       - name: List keys
         run: gpg -K
 
-      - name: Install musl
-        if: matrix.build == 'linux-musl'
+      - name: Install musl x86_64
+        if: matrix.build == 'linux-x64-musl'
         run: sudo apt install musl-tools
+
+      - name: Install gcc aarch64 cross compiler
+        if: matrix.build == 'linux-arm64'
+        run: sudo apt install gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
+
+      - name: Install musl aarch64 cross compiler
+        if: matrix.build == 'linux-arm64-musl'
+        run: |
+          curl --silent --show-error --retry 5 --fail -O https://musl.cc/aarch64-linux-musl-cross.tgz
+          tar xzf aarch64-linux-musl-cross.tgz
+          echo "${{github.workspace}}/aarch64-linux-musl-cross/bin" >> $GITHUB_PATH
 
       - name: Build release artifacts
         working-directory: artichoke


### PR DESCRIPTION
This PR adds support for building `aarch64-linux-gnu` builds during the nightly builder. The build uses a GCC cross compiler from Ubuntu Linux.

In order to get bindgen to pick up the right headers, this required passing the sysroot into bindgen via an env variable:

- https://github.com/rust-lang/rust-bindgen/issues/1229

This PR previously attempted to also add Musl aarch64 nightlies. Ubuntu Focal doesn't package an aarch64 musl cross compiler toolchain, so I tried to install one during the build from https://musl.cc/. The tarball failed to download in GitHub Actions, always timing out.

Partial fix for #77.