### PR TITLE
Use stable v1.0.0 release of artichoke/generate_third_party

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -145,8 +145,7 @@ jobs:
           echo "::set-output name=commit::${release_commit}"
 
       - name: Generate THIRDPARTY license listing
-        id: generate_third_party
-        uses: artichoke/generate_third_party@trunk
+        uses: artichoke/generate_third_party@v1.0.0
         with:
           artichoke_ref: ${{ steps.release_info.outputs.commit }}
           target_triple: ${{ matrix.target }}


### PR DESCRIPTION
Remove id from job step since it is no longer needed for capturing output.