### PR TITLE
Fix macOS version string parsing to work when there is no patch version

### DIFF
--- a/macos_sign_and_notarize.py
+++ b/macos_sign_and_notarize.py
@@ -108,7 +108,7 @@ def get_image_size(image: Path) -> int:
         capture_output=True,
         text=True,
     )
-    major, _minor, _patch = proc.stdout.strip().split(".")
+    major, *_rest = proc.stdout.strip().split(".", 1)
 
     if int(major) >= 12:
         proc = subprocess.run(


### PR DESCRIPTION
11.7 fails to parse on trunk in the latest nightly build.