### PR TITLE
Update generate_third_party GitHub Action to 1.2.0

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -149,7 +149,7 @@ jobs:
           echo "::set-output name=commit::${release_commit}"
 
       - name: Generate THIRDPARTY license listing
-        uses: artichoke/generate_third_party@v1.1.0
+        uses: artichoke/generate_third_party@v1.2.0
         with:
           artichoke_ref: ${{ steps.release_info.outputs.commit }}
           target_triple: ${{ matrix.target }}


### PR DESCRIPTION
Pull in the fix for clarify checksum mismatch on windows:

- https://github.com/artichoke/generate_third_party/pull/36