### PR TITLE
Bump artichoke/ghaction-import-gpg to v5.2.0

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -195,7 +195,7 @@ jobs:
       # ```
       - name: Import GPG key
         id: import_gpg
-        uses: artichoke/ghaction-import-gpg@v5.1.0
+        uses: artichoke/ghaction-import-gpg@v5.2.0
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_SIGNING_KEY_PASSPHRASE }}


### PR DESCRIPTION
Diff: https://github.com/artichoke/ghaction-import-gpg/compare/v5.1.0...v5.2.0

This pulls in a fix to the actions core toolkit which should silence deprecation warnings about `::set-output`.

The tag from upstream was synced to the Artichoke fork.