### PR TITLE
Add aarch64-unknown-linux-gnu builds to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,22 +36,25 @@ $ rbenv install artichoke-dev
 
 Currently supported nightly targets are:
 
+- [`aarch64-apple-darwin`] (Apple Silicon)
+- [`aarch64-unknown-linux-gnu`]
+- [`x86_64-apple-darwin`]
 - [`x86_64-unknown-linux-gnu`]
 - [`x86_64-unknown-linux-musl`]
-- [`x86_64-apple-darwin`]
 - [`x86_64-pc-windows-msvc`]
-- [`aarch64-apple-darwin`] (Apple Silicon)
 
+[`aarch64-apple-darwin`]:
+  https://github.com/artichoke/nightly/releases/latest/download/artichoke-nightly-aarch64-apple-darwin.tar.gz
+[`aarch64-unknown-linux-gnu`]:
+  https://github.com/artichoke/nightly/releases/latest/download/artichoke-nightly-aarch64-unknown-linux-gnu.tar.gz
+[`x86_64-apple-darwin`]:
+  https://github.com/artichoke/nightly/releases/latest/download/artichoke-nightly-x86_64-apple-darwin.tar.gz
 [`x86_64-unknown-linux-gnu`]:
   https://github.com/artichoke/nightly/releases/latest/download/artichoke-nightly-x86_64-unknown-linux-gnu.tar.gz
 [`x86_64-unknown-linux-musl`]:
   https://github.com/artichoke/nightly/releases/latest/download/artichoke-nightly-x86_64-unknown-linux-musl.tar.gz
-[`x86_64-apple-darwin`]:
-  https://github.com/artichoke/nightly/releases/latest/download/artichoke-nightly-x86_64-apple-darwin.tar.gz
 [`x86_64-pc-windows-msvc`]:
   https://github.com/artichoke/nightly/releases/latest/download/artichoke-nightly-x86_64-pc-windows-msvc.zip
-[`aarch64-apple-darwin`]:
-  https://github.com/artichoke/nightly/releases/latest/download/artichoke-nightly-aarch64-apple-darwin.tar.gz
 
 ## Code Signing
 


### PR DESCRIPTION
Also alphabetize targets.

Followup to #96.