### PR TITLE
Only use Python venv for macOS codesigning script

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -185,12 +185,6 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
 
-      - name: Install Python dependencies
-        run: |
-          python3 -m venv --upgrade-deps venv
-          venv/bin/pip install --upgrade pip wheel
-          venv/bin/pip install -r requirements.txt
-
       # ```
       # $ gpg --fingerprint --with-subkey-fingerprints codesign@artichokeruby.org
       # pub   ed25519 2021-01-03 [SC]
@@ -232,13 +226,20 @@ jobs:
         working-directory: artichoke
         run: cargo build --verbose --release --target ${{ matrix.target }}
 
+      - name: Install Python dependencies
+        if: runner.os == 'macOS'
+        run: |
+          python3 -m venv --upgrade-deps venv
+          ./venv/bin/pip install --upgrade pip wheel
+          ./venv/bin/pip install -r requirements.txt
+
       # This will codesign binaries in place which means that the tarballed
       # binaries will be codesigned as well.
       - name: Run Apple Codesigning and Notarization
         id: apple_codesigning
         if: runner.os == 'macOS'
         run: |
-          venv/bin/python3 macos_sign_and_notarize.py "artichoke-nightly-${{ matrix.target }}" \
+          ./venv/bin/python3 macos_sign_and_notarize.py "artichoke-nightly-${{ matrix.target }}" \
             --binary "artichoke/target/${{ matrix.target }}/release/artichoke" \
             --binary "artichoke/target/${{ matrix.target }}/release/airb" \
             --resource artichoke/LICENSE \
@@ -254,7 +255,7 @@ jobs:
         id: apple_codesigning_gpg
         if: runner.os == 'macOS'
         run: |
-          venv/bin/python3 gpg_sign.py "artichoke-nightly-${{ matrix.target }}" \
+          python3 gpg_sign.py "artichoke-nightly-${{ matrix.target }}" \
             --artifact "${{ steps.apple_codesigning.outputs.asset }}"
 
       - name: Upload release archive
@@ -308,7 +309,7 @@ jobs:
 
       - name: GPG sign archive
         id: gpg_signing
-        run: venv/bin/python3 gpg_sign.py "artichoke-nightly-${{ matrix.target }}" --artifact "${{ steps.build.outputs.asset }}"
+        run: python3 gpg_sign.py "artichoke-nightly-${{ matrix.target }}" --artifact "${{ steps.build.outputs.asset }}"
 
       - name: Upload release archive
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
For portability on Windows runners. See this failure on the 2023-04-03 nightly run:

```
venv/bin/pip: D:\a\_temp\06c848ef-3672-453c-8870-9caca73561c1.ps1:3
Line |
   3 |  venv/bin/pip install --upgrade pip wheel
     |  ~~~~~~~~~~~~
     | The term 'venv/bin/pip' is not recognized as a name of a cmdlet, function, script file, or executable program.
     | Check the spelling of the name, or if a path was included, verify that the path is correct and try again.

Error: Process completed with exit code 1.
```

https://github.com/artichoke/nightly/actions/runs/4591583224/jobs/8107866145#step:10:15