### PR TITLE
Reduce maintenance burden of `ghaction-import-gpg`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
       # ```
       - name: Import GPG key
         id: import_gpg
-        uses: artichoke/ghaction-import-gpg@v5.2.0
+        uses: crazy-max/ghaction-import-gpg@111c56156bcc6918c056dbef52164cfa583dc549 # v5.2.0
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_SIGNING_KEY_PASSPHRASE }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -197,7 +197,7 @@ jobs:
       # ```
       - name: Import GPG key
         id: import_gpg
-        uses: artichoke/ghaction-import-gpg@v5.2.0
+        uses: crazy-max/ghaction-import-gpg@111c56156bcc6918c056dbef52164cfa583dc549 # v5.2.0
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_SIGNING_KEY_PASSPHRASE }}


### PR DESCRIPTION
`ghaction-import-gpg` is a privileged GitHub Action that is passed key material for codesigning. To protect against supply chain risk, the nightly workflow used a fork of upstream pinned to a recent-ish tag. The goal with using a fork was to protect against tag mutability. See:

https://github.com/artichoke/nightly/blob/e2e0e32125b53fa98bf298ad8b5703e316643aeb/.github/workflows/nightly.yaml#L198-L204

GitHub Actions supports pinning by Git SHA and _also_ supports updating a comment that translates that SHA to a tag via dependabot.

This commit updates the CI and nightly workflows to depend on upstream as of the same tag (v5.2.0, the latest release) but pinned by SHA. Subsequent version bumps will be handled by dependabot with the auditability and informatative PRs that come with that.

After this is merged, I plan to delete the forked repository at https://github.com/artichoke/ghaction-import-gpg

See:

- https://github.com/artichoke/project-infrastructure/issues/457