### PR TITLE
Upgrade `artichoke/generate_third_party` to v1.5.0

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -149,7 +149,7 @@ jobs:
           echo "commit=${release_commit}" >> $GITHUB_OUTPUT
 
       - name: Generate THIRDPARTY license listing
-        uses: artichoke/generate_third_party@v1.3.0
+        uses: artichoke/generate_third_party@v1.5.0
         with:
           artichoke_ref: ${{ steps.release_info.outputs.commit }}
           target_triple: ${{ matrix.target }}


### PR DESCRIPTION
Includes fixes to support new bindgen deps, updates embedded mruby license for v3.2.0.

See:

- https://github.com/artichoke/generate_third_party/pull/85
- https://github.com/artichoke/generate_third_party/pull/86
- https://github.com/artichoke/artichoke/pull/2515

Related PR in nightly docker builder is:

- https://github.com/artichoke/docker-artichoke-nightly/pull/152