### PR TITLE
Use macos-latest runner for aarch64-apple-darwin nightly job

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -114,7 +114,7 @@ jobs:
             os: macos-latest
             target: x86_64-apple-darwin
           - build: macos-arm64
-            os: macos-11
+            os: macos-latest
             target: aarch64-apple-darwin
           - build: windows-x64
             os: windows-latest


### PR DESCRIPTION
The macos-11 runner only has Ruby 2.7.8, which is EOL and does not work with the generate_third_party action anymore (since v1.10.0).