### PR TITLE
Rename source archives so they sort alphabetically last

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -422,7 +422,7 @@ jobs:
         run: |
           git -C artichoke archive \
             --format ${{ matrix.archive }} \
-            --output=`pwd`/artichoke-nightly-source.${{ matrix.archive }} \
+            --output=`pwd`/artichoke-nightly.source.${{ matrix.archive }} \
             ${{ steps.release_info.outputs.commit }}
 
       - name: Install Python dependencies
@@ -437,10 +437,10 @@ jobs:
         id: build
         run: |
           if [ "${{ matrix.archive }}" = "zip" ]; then
-            echo "asset=artichoke-nightly-source.zip" >> $GITHUB_OUTPUT
+            echo "asset=artichoke-nightly.source.zip" >> $GITHUB_OUTPUT
             echo "content_type=application/zip" >> $GITHUB_OUTPUT
           else
-            echo "asset=artichoke-nightly-source.tar.gz" >> $GITHUB_OUTPUT
+            echo "asset=artichoke-nightly.source.tar.gz" >> $GITHUB_OUTPUT
             echo "content_type=application/gzip" >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
Currently the source archives sort in the middle of all the nightly releases by architecture on the GitHub Release Assets list:

```console
$ ls -1
artichoke-nightly-aarch64-apple-darwin.tar.gz
artichoke-nightly-aarch64-unknown-linux-gnu.tar.gz
artichoke-nightly-source.tar.gz
artichoke-nightly-x86_64-apple-darwin.tar.gz
```

See this release for an example:
https://github.com/artichoke/nightly/releases/tag/2023-06-05-package-source-archive-v3

With these changes, the source archive sorts last:

```console
$ ls -1
artichoke-nightly-aarch64-apple-darwin.tar.gz
artichoke-nightly-aarch64-unknown-linux-gnu.tar.gz
artichoke-nightly-x86_64-apple-darwin.tar.gz
artichoke-nightly.source.tar.gz
```

This is a followup to https://github.com/artichoke/nightly/pull/173.