### PR TITLE
Use maximum compression for git archives

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -422,6 +422,7 @@ jobs:
         run: |
           git -C artichoke archive \
             --format ${{ matrix.archive }} \
+            -9 \
             --output=`pwd`/artichoke-nightly.source.${{ matrix.archive }} \
             ${{ steps.release_info.outputs.commit }}
 


### PR DESCRIPTION
Followup to https://github.com/artichoke/nightly/pull/173.

Current archives are ~22MB. It seems worth spending some compute on compressing these further, especially since these jobs aren't the long pole of the release process.