### PR TITLE
Configure python version for actions/setup-python

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Setup Python
         uses: actions/setup-python@v5.0.0
+        with:
+          python-version-file: ".python-version"
 
       - name: Install Python dependencies
         run: |
@@ -73,6 +75,8 @@ jobs:
 
       - name: Setup Python
         uses: actions/setup-python@v5.0.0
+        with:
+          python-version-file: ".python-version"
 
       - name: Install Python dependencies
         run: |
@@ -124,6 +128,8 @@ jobs:
 
       - name: Setup Python
         uses: actions/setup-python@v5.0.0
+        with:
+          python-version-file: ".python-version"
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -171,7 +171,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5.0.0
         with:
-          python-version: "3.11"
+          python-version-file: ".python-version"
 
       - name: Set Artichoke Rust toolchain version
         id: rust_toolchain
@@ -196,6 +196,8 @@ jobs:
 
       - name: Setup Python
         uses: actions/setup-python@v5.0.0
+        with:
+          python-version-file: ".python-version"
 
       # ```
       # $ gpg --fingerprint --with-subkey-fingerprints codesign@artichokeruby.org
@@ -396,6 +398,8 @@ jobs:
 
       - name: Setup Python
         uses: actions/setup-python@v5.0.0
+        with:
+          python-version-file: ".python-version"
 
       # ```
       # $ gpg --fingerprint --with-subkey-fingerprints codesign@artichokeruby.org


### PR DESCRIPTION
The nightly builder emits this warning as of actions/setup-python@v5.0.0:

```
Warning: Neither 'python-version' nor 'python-version-file' inputs were supplied. Attempting to find '.python-version' file.
Resolved .python-version as 3.12.1
```

Fix this error by setting the `python-version-file: ".python-version"` config.