### PR TITLE
Fix broken venv python use on Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,11 +22,21 @@ jobs:
         with:
           python-version-file: ".python-version"
 
+      - name: Set Python executable path based on OS
+        shell: bash
+        run: |
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            echo "VENV_PYTHON=venv\\Scripts\\python" >> $GITHUB_ENV
+          else
+            echo "VENV_PYTHON=venv/bin/python3" >> $GITHUB_ENV
+          fi
+
       - name: Install Python dependencies
+        shell: bash
         run: |
           python3 -m venv --upgrade-deps venv
-          venv/bin/python3 -m pip install --upgrade pip wheel
-          venv/bin/python3 -m pip install --require-hashes -r requirements.txt
+          $VENV_PYTHON -m pip install --upgrade pip wheel
+          $VENV_PYTHON -m pip install --require-hashes -r requirements.txt
 
       - name: Clone Artichoke
         uses: actions/checkout@v4.1.7
@@ -60,8 +70,12 @@ jobs:
         run: cargo build --verbose --release
 
       - name: GPG sign binary
+        shell: bash
         id: gpg_signing
-        run: venv/bin/python3 -m artichoke_nightly.gpg_sign "nightly-gpg-sign-test" --artifact artichoke/target/release/artichoke
+        run: |
+          $VENV_PYTHON -m artichoke_nightly.gpg_sign \
+            "nightly-gpg-sign-test" \
+            --artifact artichoke/target/release/artichoke
 
       - name: Verify GPG signature
         run: gpg --batch --verify "${{ steps.gpg_signing.outputs.signature }}" artichoke/target/release/artichoke
@@ -78,11 +92,21 @@ jobs:
         with:
           python-version-file: ".python-version"
 
+      - name: Set Python executable path based on OS
+        shell: bash
+        run: |
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            echo "VENV_PYTHON=venv\\Scripts\\python" >> $GITHUB_ENV
+          else
+            echo "VENV_PYTHON=venv/bin/python3" >> $GITHUB_ENV
+          fi
+
       - name: Install Python dependencies
+        shell: bash
         run: |
           python3 -m venv --upgrade-deps venv
-          venv/bin/python3 -m pip install --upgrade pip wheel
-          venv/bin/python3 -m pip install --require-hashes -r requirements.txt
+          $VENV_PYTHON -m pip install --upgrade pip wheel
+          $VENV_PYTHON -m pip install --require-hashes -r requirements.txt
 
       - name: Clone Artichoke
         uses: actions/checkout@v4.1.7
@@ -97,10 +121,11 @@ jobs:
       # This will codesign binaries in place which means that the tarballed
       # binaries will be codesigned as well.
       - name: Run Apple Codesigning and Notarization
+        shell: bash
         id: apple_codesigning
         if: runner.os == 'macOS'
         run: |
-          venv/bin/python3 -m artichoke_nightly.macos_sign_and_notarize "nightly-apple-codesign-test" \
+          $VENV_PYTHON -m artichoke_nightly.macos_sign_and_notarize "nightly-apple-codesign-test" \
             --binary "artichoke/target/release/artichoke" \
             --binary "artichoke/target/release/airb" \
             --resource artichoke/LICENSE \
@@ -131,20 +156,30 @@ jobs:
         with:
           python-version-file: ".python-version"
 
+      - name: Set Python executable path based on OS
+        shell: bash
+        run: |
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            echo "VENV_PYTHON=venv\\Scripts\\python" >> $GITHUB_ENV
+          else
+            echo "VENV_PYTHON=venv/bin/python3" >> $GITHUB_ENV
+          fi
+
       - name: Install Python dependencies
+        shell: bash
         run: |
           python3 -m venv --upgrade-deps venv
-          venv/bin/python3 -m pip install --upgrade pip wheel
-          venv/bin/python3 -m pip install --require-hashes -r requirements.txt -r dev-requirements.txt
+          $VENV_PYTHON -m pip install --upgrade pip wheel
+          $VENV_PYTHON -m pip install --require-hashes -r dev-requirements.txt
 
       - name: Run black
-        run: venv/bin/black --check --diff --verbose .
+        run: $VENV_PYTHON -m black --check --diff --verbose .
 
       - name: Run ruff
-        run: venv/bin/ruff check --output-format=github .
+        run: $VENV_PYTHON -m ruff check --output-format=github .
 
       - name: Run mypy
-        run: venv/bin/mypy .
+        run: $VENV_PYTHON -m mypy .
 
   ruby:
     name: Lint and format Ruby

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -173,10 +173,26 @@ jobs:
         with:
           python-version-file: ".python-version"
 
+      - name: Set Python executable path based on OS
+        shell: bash
+        run: |
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            echo "VENV_PYTHON=venv\\Scripts\\python" >> $GITHUB_ENV
+          else
+            echo "VENV_PYTHON=venv/bin/python3" >> $GITHUB_ENV
+          fi
+
+      - name: Install Python dependencies
+        shell: bash
+        run: |
+          python3 -m venv --upgrade-deps venv
+          $VENV_PYTHON -m pip install --upgrade pip wheel
+          $VENV_PYTHON -m pip install --require-hashes -r requirements.txt
+
       - name: Set Artichoke Rust toolchain version
+        shell: python
         id: rust_toolchain
         working-directory: artichoke
-        shell: python
         run: |
           import os
           import tomllib
@@ -193,11 +209,6 @@ jobs:
         with:
           toolchain: ${{ steps.rust_toolchain.outputs.version }}
           target: ${{ matrix.target }}
-
-      - name: Setup Python
-        uses: actions/setup-python@v5.2.0
-        with:
-          python-version-file: ".python-version"
 
       # ```
       # $ gpg --fingerprint --with-subkey-fingerprints codesign@artichokeruby.org
@@ -240,19 +251,15 @@ jobs:
         working-directory: artichoke
         run: cargo build --verbose --release --target ${{ matrix.target }}
 
-      - name: Install Python dependencies
-        run: |
-          python3 -m venv --upgrade-deps venv
-          venv/bin/python3 -m pip install --upgrade pip wheel
-          venv/bin/python3 -m pip install --require-hashes -r requirements.txt
-
       # This will codesign binaries in place which means that the tarballed
       # binaries will be codesigned as well.
       - name: Run Apple Codesigning and Notarization
+        shell: bash
         id: apple_codesigning
         if: runner.os == 'macOS'
         run: |
-          venv/bin/python3 -m artichoke_nightly.macos_sign_and_notarize "artichoke-nightly-${{ matrix.target }}" \
+          $VENV_PYTHON -m artichoke_nightly.macos_sign_and_notarize \
+            "artichoke-nightly-${{ matrix.target }}" \
             --binary "artichoke/target/${{ matrix.target }}/release/artichoke" \
             --binary "artichoke/target/${{ matrix.target }}/release/airb" \
             --resource artichoke/LICENSE \
@@ -265,10 +272,12 @@ jobs:
           MACOS_CERTIFICATE_PASSPHRASE: ${{ secrets.MACOS_CERTIFICATE_PASSPHRASE }}
 
       - name: GPG sign Apple DMG
+        shell: bash
         id: apple_codesigning_gpg
         if: runner.os == 'macOS'
         run: |
-          venv/bin/python3 -m artichoke_nightly.gpg_sign "artichoke-nightly-${{ matrix.target }}" \
+          $VENV_PYTHON -m artichoke_nightly.gpg_sign \
+            "artichoke-nightly-${{ matrix.target }}" \
             --artifact "${{ steps.apple_codesigning.outputs.asset }}"
 
       - name: Upload release archive
@@ -321,8 +330,12 @@ jobs:
           fi
 
       - name: GPG sign archive
+        shell: bash
         id: gpg_signing
-        run: venv/bin/python3 -m artichoke_nightly.gpg_sign "artichoke-nightly-${{ matrix.target }}" --artifact "${{ steps.build.outputs.asset }}"
+        run: |
+          $VENV_PYTHON -m artichoke_nightly.gpg_sign \
+            "artichoke-nightly-${{ matrix.target }}" \
+            --artifact "${{ steps.build.outputs.asset }}"
 
       - name: Upload release archive
         uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5 # v1.14.0
@@ -400,6 +413,22 @@ jobs:
         with:
           python-version-file: ".python-version"
 
+      - name: Set Python executable path based on OS
+        shell: bash
+        run: |
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            echo "VENV_PYTHON=venv\\Scripts\\python" >> $GITHUB_ENV
+          else
+            echo "VENV_PYTHON=venv/bin/python3" >> $GITHUB_ENV
+          fi
+
+      - name: Install Python dependencies
+        shell: bash
+        run: |
+          python3 -m venv --upgrade-deps venv
+          $VENV_PYTHON -m pip install --upgrade pip wheel
+          $VENV_PYTHON -m pip install --require-hashes -r requirements.txt
+
       # ```
       # $ gpg --fingerprint --with-subkey-fingerprints codesign@artichokeruby.org
       # pub   ed25519 2021-01-03 [SC]
@@ -429,12 +458,6 @@ jobs:
             --output=`pwd`/artichoke-nightly.source.${{ matrix.archive }} \
             ${{ steps.release_info.outputs.commit }}
 
-      - name: Install Python dependencies
-        run: |
-          python3 -m venv --upgrade-deps venv
-          venv/bin/python3 -m pip install --upgrade pip wheel
-          venv/bin/python3 -m pip install --require-hashes -r requirements.txt
-
       - name: Build archive
         shell: bash
         id: build
@@ -448,8 +471,12 @@ jobs:
           fi
 
       - name: GPG sign archive
+        shell: bash
         id: gpg_signing
-        run: venv/bin/python3 -m artichoke_nightly.gpg_sign "artichoke-nightly-${{ matrix.target }}" --artifact "${{ steps.build.outputs.asset }}"
+        run: |
+          $VENV_PYTHON -m artichoke_nightly.gpg_sign \
+            "artichoke-nightly-source-archive" \
+            --artifact "${{ steps.build.outputs.asset }}"
 
       - name: Upload release archive
         uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5 # v1.14.0


### PR DESCRIPTION
Unify GitHub Actions stanzas across CI and nightly workflows. Always use VENV_PYTHON which is dynamically assigned based on runner OS.