### PR TITLE
Install correct Rust toolchain in codesigning CI jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,19 @@ jobs:
           repository: artichoke/artichoke
           path: artichoke
 
+      - name: Set Artichoke Rust toolchain version
+        shell: bash
+        id: rust_toolchain
+        run: |
+          uv run python -m artichoke_nightly.rust_toolchain_version \
+            --file artichoke/rust-toolchain.toml \
+            --format github
+
+      - name: Install Rust toolchain
+        uses: artichoke/setup-rust/build-and-test@68e0ebb3b406970de1cc2ca807797c9156a198a7 # v2.0.1
+        with:
+          toolchain: ${{ steps.rust_toolchain.outputs.version }}
+
       # ```
       # $ gpg --fingerprint --with-subkey-fingerprints codesign@artichokeruby.org
       # pub   ed25519 2021-01-03 [SC]
@@ -103,6 +116,19 @@ jobs:
           persist-credentials: false
           repository: artichoke/artichoke
           path: artichoke
+
+      - name: Set Artichoke Rust toolchain version
+        shell: bash
+        id: rust_toolchain
+        run: |
+          uv run python -m artichoke_nightly.rust_toolchain_version \
+            --file artichoke/rust-toolchain.toml \
+            --format github
+
+      - name: Install Rust toolchain
+        uses: artichoke/setup-rust/build-and-test@68e0ebb3b406970de1cc2ca807797c9156a198a7 # v2.0.1
+        with:
+          toolchain: ${{ steps.rust_toolchain.outputs.version }}
 
       - name: Build release artifacts
         working-directory: artichoke


### PR DESCRIPTION
Use the same `artichoke/setup-rust` action as used in the nightly builder.